### PR TITLE
chore: move common deps to pnpm workspace catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^25.6.0",
     "oxfmt": "^0.46.0",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.3",
+    "typescript": "catalog:",
     "vitest": "^4.1.5"
   },
   "packageManager": "pnpm@10.18.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,9 +43,9 @@
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
-    "effect": "4.0.0-beta.57"
+    "effect": "catalog:"
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "typescript": "catalog:"
   }
 }

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -27,11 +27,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.57"
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@betalyra/effect-uai-core": "workspace:*",
-    "typescript": "^6.0.3"
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "@betalyra/effect-uai-core": "workspace:*"

--- a/packages/responses/package.json
+++ b/packages/responses/package.json
@@ -27,11 +27,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.57"
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@betalyra/effect-uai-core": "workspace:*",
-    "typescript": "^6.0.3"
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "@betalyra/effect-uai-core": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    effect:
+      specifier: 4.0.0-beta.57
+      version: 4.0.0-beta.57
+    typescript:
+      specifier: ^6.0.3
+      version: 6.0.3
+
 importers:
 
   .:
@@ -18,7 +27,7 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
@@ -43,11 +52,11 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       effect:
-        specifier: 4.0.0-beta.57
+        specifier: 'catalog:'
         version: 4.0.0-beta.57
     devDependencies:
       typescript:
-        specifier: ^6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
 
   packages/effect-uai: {}
@@ -55,27 +64,27 @@ importers:
   packages/google:
     dependencies:
       effect:
-        specifier: 4.0.0-beta.57
+        specifier: 'catalog:'
         version: 4.0.0-beta.57
     devDependencies:
       '@betalyra/effect-uai-core':
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
 
   packages/responses:
     dependencies:
       effect:
-        specifier: 4.0.0-beta.57
+        specifier: 'catalog:'
         version: 4.0.0-beta.57
     devDependencies:
       '@betalyra/effect-uai-core':
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
 
   recipes:
@@ -93,11 +102,11 @@ importers:
         specifier: workspace:*
         version: link:../packages/responses
       effect:
-        specifier: 4.0.0-beta.57
+        specifier: 'catalog:'
         version: 4.0.0-beta.57
     devDependencies:
       typescript:
-        specifier: ^6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
 
   webpage:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,7 @@ packages:
   - "packages/*"
   - "recipes"
   - "webpage"
+
+catalog:
+  effect: 4.0.0-beta.57
+  typescript: ^6.0.3

--- a/recipes/package.json
+++ b/recipes/package.json
@@ -11,9 +11,9 @@
     "@betalyra/effect-uai-core": "workspace:*",
     "@betalyra/effect-uai-google": "workspace:*",
     "@betalyra/effect-uai-responses": "workspace:*",
-    "effect": "4.0.0-beta.57"
+    "effect": "catalog:"
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "typescript": "catalog:"
   }
 }


### PR DESCRIPTION
Centralizes shared dependency versions using the [pnpm catalog](https://pnpm.io/catalogs) feature.

### What changed
- Added a `catalog:` section to `pnpm-workspace.yaml` with:
  - `effect`: `4.0.0-beta.57`
  - `typescript`: `^6.0.3`
- Replaced hardcoded versions with `"catalog:"` in every workspace `package.json` that used these deps (root, core, google, responses, recipes).
- Regenerated `pnpm-lock.yaml`.

### Why
Keeps versions of shared deps in sync across all packages from a single place, reducing drift and merge-conflict surface.