### PR TITLE
Add optional Nix flake dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# Load the Nix dev shell from flake.nix when you cd into the repo.
+# Requires direnv (https://direnv.net); run `direnv allow` once to enable.
+# Entirely optional — the shell only activates if you have direnv installed.
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ coverage/
 *.mp3
 *.wav
 *.pcm
+
+# Nix
+.corepack/
+.direnv/
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -161,6 +161,24 @@ To run a recipe end-to-end against real providers:
 OPENAI_API_KEY=sk-... pnpm tsx recipes/basic-usage/run.ts
 ```
 
+### Nix dev shell (optional)
+
+This repo ships a `flake.nix` that provides a dev shell with the exact
+toolchain CI uses - Node 24, the pinned pnpm version (via corepack), and
+Deno for the integration tests. It is **100% optional**: if you already
+have Node and pnpm installed, ignore this entirely and use the commands
+above.
+
+If you do use [Nix](https://nixos.org/download) with flakes enabled:
+
+```bash
+nix develop          # drops you into a shell with node, pnpm and deno
+```
+
+The repo also ships an `.envrc`, so with [direnv](https://direnv.net/)
+installed the shell loads automatically when you `cd` in - just run
+`direnv allow` once. Without direnv the file is inert and ignored.
+
 ## License
 
 MIT - see [LICENSE](./LICENSE).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "effect-uai — low-level primitives for AI agents in Effect";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      # Systems we provide a devShell for: the standard set flakes expose.
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed
+          (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          # Toolchain mirrors CI (.github/workflows/ci.yml): Node 24 + pnpm.
+          # pnpm is pinned to the version in package.json's `packageManager`
+          # field via corepack (see shellHook), so it always matches CI exactly.
+          packages = [
+            pkgs.nodejs_24
+            pkgs.corepack       # provides the pnpm version pinned in package.json
+            pkgs.deno           # only needed for the deno integration-test suite
+            pkgs.git
+          ];
+
+          shellHook = ''
+            # Activate the pnpm version pinned in package.json without writing
+            # to the read-only Nix store: keep corepack's shims under the repo.
+            export COREPACK_HOME="$PWD/.corepack"
+            export PATH="$COREPACK_HOME/bin:$PATH"
+            mkdir -p "$COREPACK_HOME/bin"
+            corepack enable --install-directory "$COREPACK_HOME/bin" pnpm >/dev/null 2>&1 || true
+
+            echo "effect-uai dev shell"
+            echo "  node $(node --version)"
+            echo "  pnpm $(pnpm --version 2>/dev/null || echo '(run: corepack prepare --activate)')"
+            echo "  deno $(deno --version | head -n1 | cut -d' ' -f2)"
+          '';
+        };
+      });
+    };
+}


### PR DESCRIPTION
Provides a reproducible dev shell mirroring CI: Node 24, the pinned pnpm version (via corepack), and Deno for the integration tests. Ships an .envrc for automatic activation with direnv. Entirely optional — existing Node/pnpm setups are unaffected.