### PR TITLE
Accept Effect Schema directly as tool inputSchema

### DIFF
--- a/packages/core/src/tool/Tool.test.ts
+++ b/packages/core/src/tool/Tool.test.ts
@@ -1,5 +1,5 @@
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
-import { Effect } from "effect"
+import { Context, Effect, Schema } from "effect"
 import { describe, expect, expectTypeOf, it } from "vitest"
 import type * as Items from "../domain/Items.js"
 import * as Tool from "./Tool.js"
@@ -154,5 +154,106 @@ describe("Tool.decodeArgs", () => {
   it("fails with ToolError when the arguments don't satisfy the schema", async () => {
     const exit = await Effect.runPromiseExit(Tool.decodeArgs(sendEmail, callWith('{"to":42}')))
     expect(exit._tag).toBe("Failure")
+  })
+})
+
+describe("Effect Schema inputSchema", () => {
+  const Recipient = Schema.Struct({ to: Schema.String })
+
+  const sendEmail = Tool.make({
+    name: "send_email",
+    description: "Send an email to a single recipient.",
+    inputSchema: Recipient,
+    run: ({ to }) => Effect.succeed(`queued: ${to}`),
+  })
+
+  const callWith = (args: string): Items.ToolCall => ({
+    type: "function_call",
+    call_id: "call_1",
+    name: "send_email",
+    arguments: args,
+  })
+
+  it("runs with the input inferred from the schema's Type", async () => {
+    const result = await Effect.runPromise(sendEmail.run({ to: "x@y.z" }, () => Effect.void))
+    expect(result).toBe("queued: x@y.z")
+  })
+
+  it("type: Input is the schema's Type", () => {
+    type InputOf<T> = T extends Tool.Tool<string, infer I, any, any, any> ? I : never
+    expectTypeOf<InputOf<typeof sendEmail>>().toEqualTypeOf<{ readonly to: string }>()
+  })
+
+  it("type: E and R are inferred from run through the Effect Schema overload", () => {
+    class Mailer extends Context.Service<
+      Mailer,
+      { readonly send: (to: string) => Effect.Effect<string> }
+    >()("test/Mailer") {}
+
+    const tool = Tool.make({
+      name: "send_email",
+      description: "send",
+      inputSchema: Recipient,
+      run: ({ to }) =>
+        Effect.gen(function* () {
+          const mailer = yield* Mailer
+          if (to === "") return yield* Effect.fail("empty" as const)
+          return yield* mailer.send(to)
+        }),
+    })
+
+    expectTypeOf<Tool.ToolE<typeof tool>>().toEqualTypeOf<"empty">()
+    expectTypeOf<Tool.ToolR<typeof tool>>().toEqualTypeOf<Mailer>()
+  })
+
+  it("decodes valid JSON arguments to the typed input", async () => {
+    const input = await Effect.runPromise(Tool.decodeArgs(sendEmail, callWith('{"to":"x@y.z"}')))
+    expect(input).toEqual({ to: "x@y.z" })
+    expectTypeOf(input).toEqualTypeOf<{ readonly to: string }>()
+  })
+
+  it("fails with ToolValidationError when the arguments don't satisfy the schema", async () => {
+    const exit = await Effect.runPromiseExit(Tool.decodeArgs(sendEmail, callWith('{"to":42}')))
+    expect(exit._tag).toBe("Failure")
+  })
+
+  it("renders a JSON Schema descriptor from the wrapped schema", () => {
+    const [descriptor] = Tool.toDescriptors([sendEmail])
+    expect(descriptor?.name).toBe("send_email")
+    expect(descriptor?.inputSchema).toMatchObject({
+      type: "object",
+      properties: { to: { type: "string" } },
+      required: ["to"],
+    })
+  })
+
+  it("accepts an already-wrapped fromEffectSchema value unchanged", async () => {
+    const wrapped = Tool.make({
+      name: "send_email",
+      description: "Send an email to a single recipient.",
+      inputSchema: Tool.fromEffectSchema(Recipient),
+      run: ({ to }) => Effect.succeed(`queued: ${to}`),
+    })
+    expect(Tool.toDescriptors([wrapped])).toEqual(Tool.toDescriptors([sendEmail]))
+    const input = await Effect.runPromise(Tool.decodeArgs(wrapped, callWith('{"to":"x@y.z"}')))
+    expectTypeOf(input).toEqualTypeOf<{ readonly to: string }>()
+  })
+
+  it("signal: decode-only kinds accept an Effect Schema directly", async () => {
+    const escalate = Tool.signal({
+      name: "escalate",
+      description: "Escalate to a human.",
+      inputSchema: Schema.Struct({ reason: Schema.String }),
+    })
+    const input = await Effect.runPromise(
+      Tool.decodeArgs(escalate, {
+        type: "function_call",
+        call_id: "call_2",
+        name: "escalate",
+        arguments: '{"reason":"stuck"}',
+      }),
+    )
+    expect(input).toEqual({ reason: "stuck" })
+    expectTypeOf(input).toEqualTypeOf<{ readonly reason: string }>()
   })
 })

--- a/packages/core/src/tool/Tool.ts
+++ b/packages/core/src/tool/Tool.ts
@@ -244,37 +244,114 @@ export type ToolDescriptor = {
   readonly strict?: boolean
 }
 
+const resolveInputSchema = (
+  schema: ToolInputSchema<any> | Schema.Codec<any, any, never, any>,
+): ToolInputSchema<any> =>
+  Schema.isSchema(schema)
+    ? fromEffectSchema(schema as Schema.Codec<any, any, never, any>)
+    : (schema as ToolInputSchema<any>)
+
 /** A model-visible tool with a local `Effect` executor. */
-export const make = <Name extends string, Input, Event, Output, E = never, R = never>(
-  spec: Omit<Tool<Name, Input, Event, Output, E, R>, "_tag">,
-): Tool<Name, Input, Event, Output, E, R> => ({ _tag: "LocalTool", ...spec })
+export const make: {
+  <
+    Name extends string,
+    S extends Schema.Codec<any, any, never, any>,
+    Event,
+    Output,
+    E = never,
+    R = never,
+  >(
+    spec: Omit<Tool<Name, S["Type"], Event, Output, E, R>, "_tag" | "inputSchema"> & {
+      readonly inputSchema: S
+    },
+  ): Tool<Name, S["Type"], Event, Output, E, R>
+  <Name extends string, Input, Event, Output, E = never, R = never>(
+    spec: Omit<Tool<Name, Input, Event, Output, E, R>, "_tag">,
+  ): Tool<Name, Input, Event, Output, E, R>
+} = (
+  spec: Omit<AnyLocalTool, "_tag" | "inputSchema"> & {
+    readonly inputSchema: ToolInputSchema<any> | Schema.Codec<any, any, never, any>
+  },
+): AnyLocalTool => ({
+  _tag: "LocalTool",
+  ...spec,
+  inputSchema: resolveInputSchema(spec.inputSchema),
+})
 
 /**
  * A provider-hosted tool (native web search, code execution, RAG grounding).
  * No local executor — `provider`/`config` drive the provider adapter's
  * rendering. The model sees it; `Toolkit.run` reports it as `non_local_tool`.
  */
-export const provider = <Name extends string, Input, Provider extends string, Config>(
-  spec: Omit<ProviderTool<Name, Input, Provider, Config>, "_tag">,
-): ProviderTool<Name, Input, Provider, Config> => ({ _tag: "ProviderTool", ...spec })
+export const provider: {
+  <
+    Name extends string,
+    S extends Schema.Codec<any, any, never, any>,
+    Provider extends string,
+    Config,
+  >(
+    spec: Omit<ProviderTool<Name, S["Type"], Provider, Config>, "_tag" | "inputSchema"> & {
+      readonly inputSchema: S
+    },
+  ): ProviderTool<Name, S["Type"], Provider, Config>
+  <Name extends string, Input, Provider extends string, Config>(
+    spec: Omit<ProviderTool<Name, Input, Provider, Config>, "_tag">,
+  ): ProviderTool<Name, Input, Provider, Config>
+} = (
+  spec: Omit<ProviderTool<string, any, string, any>, "_tag" | "inputSchema"> & {
+    readonly inputSchema: ToolInputSchema<any> | Schema.Codec<any, any, never, any>
+  },
+): ProviderTool<string, any, string, any> => ({
+  _tag: "ProviderTool",
+  ...spec,
+  inputSchema: resolveInputSchema(spec.inputSchema),
+})
 
 /**
  * A typed control-flow signal to the agent loop (escalate, pause, schedule,
  * hand off). Decode-only: the loop interprets the call rather than executing a
  * handler, so there is no `run`.
  */
-export const signal = <Name extends string, Input>(
-  spec: Omit<SignalTool<Name, Input>, "_tag">,
-): SignalTool<Name, Input> => ({ _tag: "SignalTool", ...spec })
+export const signal: {
+  <Name extends string, S extends Schema.Codec<any, any, never, any>>(
+    spec: Omit<SignalTool<Name, S["Type"]>, "_tag" | "inputSchema"> & {
+      readonly inputSchema: S
+    },
+  ): SignalTool<Name, S["Type"]>
+  <Name extends string, Input>(spec: Omit<SignalTool<Name, Input>, "_tag">): SignalTool<Name, Input>
+} = (
+  spec: Omit<SignalTool<string, any>, "_tag" | "inputSchema"> & {
+    readonly inputSchema: ToolInputSchema<any> | Schema.Codec<any, any, never, any>
+  },
+): SignalTool<string, any> => ({
+  _tag: "SignalTool",
+  ...spec,
+  inputSchema: resolveInputSchema(spec.inputSchema),
+})
 
 /**
  * A typed request for an external actor to respond before the loop resumes
  * (frontend, Telegram, CLI prompt). Decode-only; the loop stops/pauses and
  * resumes by appending the actor's `function_call_output`.
  */
-export const interaction = <Name extends string, Input>(
-  spec: Omit<InteractionTool<Name, Input>, "_tag">,
-): InteractionTool<Name, Input> => ({ _tag: "InteractionTool", ...spec })
+export const interaction: {
+  <Name extends string, S extends Schema.Codec<any, any, never, any>>(
+    spec: Omit<InteractionTool<Name, S["Type"]>, "_tag" | "inputSchema"> & {
+      readonly inputSchema: S
+    },
+  ): InteractionTool<Name, S["Type"]>
+  <Name extends string, Input>(
+    spec: Omit<InteractionTool<Name, Input>, "_tag">,
+  ): InteractionTool<Name, Input>
+} = (
+  spec: Omit<InteractionTool<string, any>, "_tag" | "inputSchema"> & {
+    readonly inputSchema: ToolInputSchema<any> | Schema.Codec<any, any, never, any>
+  },
+): InteractionTool<string, any> => ({
+  _tag: "InteractionTool",
+  ...spec,
+  inputSchema: resolveInputSchema(spec.inputSchema),
+})
 
 /**
  * Return a copy of a tool under a new `name`. Useful for resolving a name


### PR DESCRIPTION
DX improvement for Effect Schema users: the four tool constructors (`Tool.make`, `Tool.provider`, `Tool.signal`, `Tool.interaction`) now accept an Effect Schema directly as `inputSchema`, dropping the `Tool.fromEffectSchema` ceremony at every call site.

```ts
Tool.make({
  name: "send_email",
  description: "Send an email.",
  inputSchema: Schema.Struct({ to: Schema.String }),
  run: ({ to }) => Effect.succeed(`queued: ${to}`),
})
```

The overload constrains to `Schema.Codec<any, any, never, any>` (what `toStandardSchemaV1` itself requires, so service-requiring schemas are rejected at compile time) and infers the input via `S["Type"]`. Standard Schema values fall through to the unchanged original signature, so existing call sites resolve identically. Normalization happens once at construction via `Schema.isSchema` + the existing `fromEffectSchema` (idempotent for already-wrapped values).