### PR TITLE
Fix type-level name prefixing in Toolkit.namespace

### DIFF
--- a/packages/core/src/tool/Toolkit.test.ts
+++ b/packages/core/src/tool/Toolkit.test.ts
@@ -252,6 +252,66 @@ describe("Toolkit.make / compose / namespace - uniqueness", () => {
   })
 })
 
+describe("Toolkit.namespace - typed toolkits", () => {
+  const Query = Schema.Struct({ q: Schema.String })
+  type GeoShape = { readonly lookup: (q: string) => Effect.Effect<string> }
+  class Geo extends Context.Service<Geo, GeoShape>()("test/Geo") {}
+
+  const search = Tool.make({
+    name: "search",
+    description: "",
+    inputSchema: Tool.fromEffectSchema(Query),
+    run: ({ q }) =>
+      Effect.gen(function* () {
+        const geo = yield* Geo
+        if (q === "") return yield* Effect.fail("empty_query" as const)
+        return yield* geo.lookup(q)
+      }),
+  })
+
+  const kit = Toolkit.namespace("geo", Toolkit.make(search))
+
+  it("type: prefixes the name literal of a service-requiring tool", () => {
+    expectTypeOf(kit.geo__search.name).toEqualTypeOf<"geo__search">()
+  })
+
+  it("type: preserves E and R through namespace", () => {
+    expectTypeOf<Toolkit.ToolkitE<typeof kit>>().toEqualTypeOf<"empty_query">()
+    expectTypeOf<Toolkit.ToolkitR<typeof kit>>().toEqualTypeOf<Geo>()
+  })
+
+  it("type: preserves E and R through makeNamespaced", () => {
+    const namespaced = Toolkit.makeNamespaced("geo", search)
+    expectTypeOf(namespaced.geo__search.name).toEqualTypeOf<"geo__search">()
+    expectTypeOf<Toolkit.ToolkitE<typeof namespaced>>().toEqualTypeOf<"empty_query">()
+    expectTypeOf<Toolkit.ToolkitR<typeof namespaced>>().toEqualTypeOf<Geo>()
+  })
+
+  it("type: Toolkit.run surfaces the namespaced tool's R (string E is absorbed)", () => {
+    const stream = Toolkit.run(kit, [])
+    expectTypeOf(stream).toEqualTypeOf<
+      Stream.Stream<import("./ToolEvent.js").ToolEvent, never, Geo>
+    >()
+  })
+
+  it("runtime: renames the tool and executes it under the prefixed name", async () => {
+    const call: ToolCall = {
+      type: "function_call",
+      call_id: "call_1",
+      name: "geo__search",
+      arguments: '{"q":"lisbon"}',
+    }
+    const events = await Effect.runPromise(
+      Stream.runCollect(Toolkit.run(kit, [call])).pipe(
+        Effect.provide(Layer.succeed(Geo, { lookup: (q) => Effect.succeed(`geo:${q}`) })),
+      ),
+    )
+    const outputs = events.filter(isOutput).map((e) => e.result)
+    expect(outputs).toHaveLength(1)
+    expect(outputs[0]).toMatchObject({ _tag: "Ok", tool: "geo__search", value: "geo:lisbon" })
+  })
+})
+
 describe("Toolkit.wrap - middleware", () => {
   const Empty = Schema.Struct({})
   type AuditShape = { readonly record: (name: string) => Effect.Effect<void> }

--- a/packages/core/src/tool/Toolkit.ts
+++ b/packages/core/src/tool/Toolkit.ts
@@ -186,8 +186,8 @@ export class DuplicateToolName extends Data.TaggedError("DuplicateToolName")<{
 type PrefixName<Prefix extends string, Name extends string> = `${Prefix}__${Name}`
 
 type PrefixTool<Prefix extends string, T extends AnyTool> =
-  T extends Tool<infer N, infer I, infer Ev, infer O, infer R>
-    ? Tool<PrefixName<Prefix, N>, I, Ev, O, R>
+  T extends Tool<infer N, infer I, infer Ev, infer O, infer E, infer R>
+    ? Tool<PrefixName<Prefix, N>, I, Ev, O, E, R>
     : T extends ProviderTool<infer N, infer I, infer P, infer C>
       ? ProviderTool<PrefixName<Prefix, N>, I, P, C>
       : T extends SignalTool<infer N, infer I>


### PR DESCRIPTION
`PrefixTool` destructured the 6-generic `Tool<Name, Input, Event, Output, E, R>` with only 5 `infer` slots, so the 5th `infer` bound to `E` and the pattern's `R` slot took its `never` default. Because `Effect`'s `R` is covariant (`out R`), any tool with `R ≠ never` failed the conditional and fell through to the un-prefixed `: T` fallback — the `name` literal type stayed un-prefixed while the record key was prefixed, breaking the key ↔ `tool.name` invariant (tools with `R = never` happened to match the buggy branch with `E` landing back in the right slot, so they were unaffected).

The fix infers all six generics and re-emits them in order, matching the sibling `WrapTool`/`DescribeTool` destructurings. Added a `Toolkit.namespace - typed toolkits` regression suite pinning the prefixed name literal, `E`/`R` preservation through `namespace`/`makeNamespaced`, `Toolkit.run`'s derived channels (`R = Geo`, string `E` absorbed to `never`), and runtime execution under the prefixed name — the name-literal assertions fail typecheck on the unfixed code.