### PR TITLE
Fix Mistral synthesizing TurnComplete for truncated and failed streams

### DIFF
--- a/packages/providers/mistral/src/Mistral.ts
+++ b/packages/providers/mistral/src/Mistral.ts
@@ -145,7 +145,12 @@ const buildStream = (cfg: Config) => {
             Option.isSome(chunk) ? Result.succeed(chunk.value) : Result.failVoid,
           ),
           Stream.mapAccum((): Accumulator => emptyAccumulator, applyChunk, {
-            onHalt: (acc) => [TurnEvent.TurnComplete({ turn: accumulatorToTurn(acc) })],
+            // `onHalt` also fires on upstream failure and truncated streams,
+            // so only emit `TurnComplete` once a `finish_reason` was observed
+            onHalt: (acc) =>
+              Option.isSome(acc.finishReason)
+                ? [TurnEvent.TurnComplete({ turn: accumulatorToTurn(acc) })]
+                : [],
           }),
         )
       }),

--- a/packages/providers/mistral/src/onHalt.test.ts
+++ b/packages/providers/mistral/src/onHalt.test.ts
@@ -1,0 +1,75 @@
+import { Effect, Exit, Redacted, Stream } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+import { describe, expect, it } from "vitest"
+import { TurnEvent } from "@effect-uai/core/Turn"
+import { make as makeMistral } from "./Mistral.js"
+
+// An HttpClient backed by a scripted SSE body
+const clientWithBody = (makeBody: () => ReadableStream<Uint8Array>): HttpClient.HttpClient =>
+  HttpClient.make((request) =>
+    Effect.succeed(
+      HttpClientResponse.fromWeb(
+        request,
+        new Response(makeBody(), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+      ),
+    ),
+  )
+
+const enc = new TextEncoder()
+const sse = (obj: unknown) => enc.encode(`data: ${JSON.stringify(obj)}\n\n`)
+
+const runStream = (client: HttpClient.HttpClient) =>
+  Effect.gen(function* () {
+    const svc = yield* makeMistral({ apiKey: Redacted.make("k") })
+    const events: Array<TurnEvent> = []
+    const exit = yield* svc.streamTurn({ model: "mistral-small-latest", history: [] }).pipe(
+      Stream.runForEach((e) => Effect.sync(() => events.push(e))),
+      Effect.exit,
+    )
+    return { tags: events.map((e) => e._tag), events, exit }
+  }).pipe(Effect.provideService(HttpClient.HttpClient, client))
+
+describe("Mistral streamTurn: truncated turn presented as complete", () => {
+  it("truncated EOF (no finish_reason) must not synthesize a complete turn", async () => {
+    const body = () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(sse({ choices: [{ delta: { content: "Hel" } }] }))
+          controller.close() // no finish_reason, no [DONE]
+        },
+      })
+    const { tags } = await Effect.runPromise(runStream(clientWithBody(body)))
+    expect(tags).toContain("TextDelta")
+    expect(tags).not.toContain("TurnComplete")
+  })
+
+  it("mid-stream error must surface as a failure, not a fake TurnComplete", async () => {
+    const body = () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(sse({ choices: [{ delta: { content: "Hel" } }] }))
+          controller.error(new Error("connection reset"))
+        },
+      })
+    const { tags, exit } = await Effect.runPromise(runStream(clientWithBody(body)))
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(tags).not.toContain("TurnComplete")
+  })
+
+  it("a well-formed stream (finish_reason present) still completes", async () => {
+    const body = () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(sse({ choices: [{ delta: { content: "Hel" } }] }))
+          controller.enqueue(sse({ choices: [{ delta: {}, finish_reason: "stop" }] }))
+          controller.enqueue(enc.encode("data: [DONE]\n\n"))
+          controller.close()
+        },
+      })
+    const { tags } = await Effect.runPromise(runStream(clientWithBody(body)))
+    expect(tags).toContain("TurnComplete")
+  })
+})


### PR DESCRIPTION
In effect 4.0.0-beta.57, `Stream.mapAccum`'s `onHalt` runs for every terminal cause (`Channel.ts` invokes it from the failure handler, and stream end is a `Cause.Done` failure) — not just clean completion. Mistral's `buildStream` unconditionally synthesized `TurnComplete` there, so a stream that truncated without a `finish_reason` yielded a partial turn labeled `stop_reason: "stop"`, and a mid-stream transport failure emitted a fake `TurnComplete` before the error surfaced — a loop acting on `TurnComplete` commits a partial turn as complete right before seeing the failure.

The fix gates the synthesis on an observed `finish_reason` (matching how the Gemini provider only completes on `result.finished`); on truncation/failure `onHalt` returns `[]`, which re-raises the original cause unchanged, so a truncated stream now surfaces as `IncompleteTurn` via `turnFromStream` like the other providers. The wire schema accepts any `finish_reason` string, so every legitimate completion (`stop`, `length`, `tool_calls`, `content_filter`, unknown future values) still emits `TurnComplete`, including when usage arrives on a separate final chunk.

Regression test drives the real `streamTurn` pipeline through an in-memory HttpClient with a scripted SSE body: truncated EOF and mid-stream error emit no `TurnComplete`; a well-formed stream still completes. Also reproduced and verified live against a local Mistral-7B (OpenAI-compatible SSE dialect) with a real mid-stream socket cut. Heads-up: the same `onHalt`-fires-on-failure contract affects the tail-flush in core's `SSE.ts`/`JSONL.ts` — happy to send a separate PR for those.