### PR TITLE
Back SSE and JSONL decoders with effect unstable/encoding

### DIFF
--- a/packages/core/src/streaming/JSONL.test.ts
+++ b/packages/core/src/streaming/JSONL.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Result, Schema, Stream } from "effect"
+import { Cause, Effect, Exit, Result, Schema, Stream } from "effect"
 import { describe, expect, it } from "vitest"
 import * as JSONL from "./JSONL.js"
 
@@ -7,6 +7,19 @@ const bytesOf = (...chunks: ReadonlyArray<string>) =>
   Stream.fromIterable(chunks.map((c) => enc.encode(c)))
 
 const collect = <A, E>(s: Stream.Stream<A, E>) => Effect.runPromise(Stream.runCollect(s))
+
+const runUntilEnd = <A>(s: Stream.Stream<A, unknown>) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const seen: Array<A> = []
+      const exit = yield* Stream.runForEach(s, (a) =>
+        Effect.sync(() => {
+          seen.push(a)
+        }),
+      ).pipe(Effect.exit)
+      return { seen, exit }
+    }),
+  )
 
 const collectResult = <A, E>(s: Stream.Stream<A, E>) =>
   Effect.runPromise(Effect.result(Stream.runCollect(s)))
@@ -32,6 +45,16 @@ describe("JSONL.fromBytes", () => {
   it("ignores blank lines", async () => {
     const out = await collect(JSONL.fromBytes(bytesOf("a\n\n\nb\n")))
     expect(out).toEqual(["a", "b"])
+  })
+
+  it("discards a buffered partial line when the upstream fails mid-stream", async () => {
+    const failing = Stream.concat(bytesOf('{"n":1}\n{"n":2'), Stream.fail("boom" as const))
+    const { seen, exit } = await runUntilEnd(JSONL.fromBytes(failing))
+    expect(seen).toEqual(['{"n":1}'])
+    const failures = Exit.isFailure(exit)
+      ? exit.cause.reasons.filter(Cause.isFailReason).map((r) => r.error)
+      : []
+    expect(failures).toEqual(["boom"])
   })
 })
 

--- a/packages/core/src/streaming/JSONL.test.ts
+++ b/packages/core/src/streaming/JSONL.test.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Exit, Result, Schema, Stream } from "effect"
+import { Effect, Result, Schema, Stream } from "effect"
 import { describe, expect, it } from "vitest"
 import * as JSONL from "./JSONL.js"
 
@@ -8,17 +8,17 @@ const bytesOf = (...chunks: ReadonlyArray<string>) =>
 
 const collect = <A, E>(s: Stream.Stream<A, E>) => Effect.runPromise(Stream.runCollect(s))
 
-const runUntilEnd = <A>(s: Stream.Stream<A, unknown>) =>
+const runUntilEnd = <A, E>(s: Stream.Stream<A, E>) =>
   Effect.runPromise(
-    Effect.gen(function* () {
-      const seen: Array<A> = []
-      const exit = yield* Stream.runForEach(s, (a) =>
-        Effect.sync(() => {
-          seen.push(a)
-        }),
-      ).pipe(Effect.exit)
-      return { seen, exit }
-    }),
+    s.pipe(
+      Stream.map((a): Result.Result<A, E> => Result.succeed(a)),
+      Stream.catch((e) => Stream.succeed<Result.Result<A, E>>(Result.fail(e))),
+      Stream.runCollect,
+      Effect.map((results) => ({
+        seen: results.filter(Result.isSuccess).map((r) => r.success),
+        failures: results.filter(Result.isFailure).map((r) => r.failure),
+      })),
+    ),
   )
 
 const collectResult = <A, E>(s: Stream.Stream<A, E>) =>
@@ -49,11 +49,8 @@ describe("JSONL.fromBytes", () => {
 
   it("discards a buffered partial line when the upstream fails mid-stream", async () => {
     const failing = Stream.concat(bytesOf('{"n":1}\n{"n":2'), Stream.fail("boom" as const))
-    const { seen, exit } = await runUntilEnd(JSONL.fromBytes(failing))
+    const { seen, failures } = await runUntilEnd(JSONL.fromBytes(failing))
     expect(seen).toEqual(['{"n":1}'])
-    const failures = Exit.isFailure(exit)
-      ? exit.cause.reasons.filter(Cause.isFailReason).map((r) => r.error)
-      : []
     expect(failures).toEqual(["boom"])
   })
 })

--- a/packages/core/src/streaming/JSONL.test.ts
+++ b/packages/core/src/streaming/JSONL.test.ts
@@ -11,8 +11,7 @@ const collect = <A, E>(s: Stream.Stream<A, E>) => Effect.runPromise(Stream.runCo
 const runUntilEnd = <A, E>(s: Stream.Stream<A, E>) =>
   Effect.runPromise(
     s.pipe(
-      Stream.map((a): Result.Result<A, E> => Result.succeed(a)),
-      Stream.catch((e) => Stream.succeed<Result.Result<A, E>>(Result.fail(e))),
+      Stream.result,
       Stream.runCollect,
       Effect.map((results) => ({
         seen: results.filter(Result.isSuccess).map((r) => r.success),

--- a/packages/core/src/streaming/JSONL.ts
+++ b/packages/core/src/streaming/JSONL.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, Schema, Stream } from "effect"
+import { Channel, Data, Effect, Schema, Stream } from "effect"
 
 export class JsonParseError extends Data.TaggedError("JsonParseError")<{
   readonly line: string
@@ -6,53 +6,21 @@ export class JsonParseError extends Data.TaggedError("JsonParseError")<{
 }> {}
 
 // ---------------------------------------------------------------------------
-// Generic stream helpers (kept module-local; see SSE.ts for the same shape).
-// ---------------------------------------------------------------------------
-
-const decodeText = <E, R>(self: Stream.Stream<Uint8Array, E, R>): Stream.Stream<string, E, R> =>
-  self.pipe(
-    Stream.mapAccum(
-      (): TextDecoder => new TextDecoder("utf-8"),
-      (decoder, chunk: Uint8Array) => [decoder, [decoder.decode(chunk, { stream: true })]] as const,
-      {
-        onHalt: (decoder: TextDecoder) => {
-          const tail = decoder.decode()
-          return tail.length > 0 ? [tail] : []
-        },
-      },
-    ),
-  )
-
-const splitOn =
-  (separator: string) =>
-  <E, R>(self: Stream.Stream<string, E, R>): Stream.Stream<string, E, R> =>
-    self.pipe(
-      Stream.mapAccum(
-        (): string => "",
-        (buffer, chunk: string) => {
-          const parts = (buffer + chunk).split(separator)
-          const tail = parts[parts.length - 1] ?? ""
-          return [tail, parts.slice(0, -1)] as const
-        },
-        { onHalt: (tail: string) => (tail.length > 0 ? [tail] : []) },
-      ),
-    )
-
-// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /**
  * Decode a `Stream<Uint8Array>` into a `Stream<string>` of newline-delimited
- * lines. Empty lines are skipped. Buffers across chunk boundaries.
+ * lines. Empty lines are skipped. Buffers across chunk boundaries; a final
+ * line without a trailing newline is emitted at clean stream end, while a
+ * buffered partial line is discarded if the stream fails.
  */
 export const fromBytes = <E, R>(
   self: Stream.Stream<Uint8Array, E, R>,
 ): Stream.Stream<string, E, R> =>
   self.pipe(
-    decodeText,
-    Stream.map((s) => s.replace(/\r/g, "")),
-    splitOn("\n"),
+    Stream.decodeText,
+    Stream.pipeThroughChannel(Channel.splitLines()),
     Stream.filter((line) => line.length > 0),
   )
 

--- a/packages/core/src/streaming/SSE.test.ts
+++ b/packages/core/src/streaming/SSE.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Stream } from "effect"
 import { describe, expect, it } from "vitest"
 import * as SSE from "./SSE.js"
 
@@ -7,6 +7,22 @@ const bytesOf = (...chunks: ReadonlyArray<string>) =>
   Stream.fromIterable(chunks.map((c) => enc.encode(c)))
 
 const collect = <A, E>(s: Stream.Stream<A, E>) => Effect.runPromise(Stream.runCollect(s))
+
+const runUntilEnd = <A>(s: Stream.Stream<A, unknown>) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const seen: Array<A> = []
+      const exit = yield* Stream.runForEach(s, (a) =>
+        Effect.sync(() => {
+          seen.push(a)
+        }),
+      ).pipe(Effect.exit)
+      return { seen, exit }
+    }),
+  )
+
+const failuresOf = (exit: Exit.Exit<unknown, unknown>): ReadonlyArray<unknown> =>
+  Exit.isFailure(exit) ? exit.cause.reasons.filter(Cause.isFailReason).map((r) => r.error) : []
 
 describe("SSE.fromBytes", () => {
   it("parses a single complete event", async () => {
@@ -39,9 +55,77 @@ describe("SSE.fromBytes", () => {
     expect(out).toEqual([{ id: "42", data: "x" }])
   })
 
-  it("flushes a trailing event without a closing blank line", async () => {
+  it("parses a data field with no space after the colon", async () => {
+    const out = await collect(SSE.fromBytes(bytesOf("data:x\n\n")))
+    expect(out).toEqual([{ data: "x" }])
+  })
+
+  it("ignores an id containing a NUL character", async () => {
+    const out = await collect(SSE.fromBytes(bytesOf("id: a\u0000b\ndata: x\n\n")))
+    expect(out).toEqual([{ data: "x" }])
+  })
+
+  it("discards a trailing event without a closing blank line", async () => {
     const out = await collect(SSE.fromBytes(bytesOf("data: tail")))
-    expect(out).toEqual([{ data: "tail" }])
+    expect(out).toEqual([])
+  })
+
+  it("discards buffered partial data when the upstream fails mid-stream", async () => {
+    const failing = Stream.concat(
+      bytesOf("data: good\n\ndata: partial-tr"),
+      Stream.fail("boom" as const),
+    )
+    const { seen, exit } = await runUntilEnd(SSE.fromBytes(failing))
+    expect(seen).toEqual([{ data: "good" }])
+    expect(failuresOf(exit)).toEqual(["boom"])
+  })
+
+  it("discards a partial multi-byte char in the text decoder when the upstream fails", async () => {
+    const partialSquid = enc.encode("data: 🦑\n\n").slice(0, 8)
+    const failing = Stream.concat(
+      Stream.fromIterable([enc.encode("data: ok\n\n"), partialSquid]),
+      Stream.fail("boom" as const),
+    )
+    const { seen, exit } = await runUntilEnd(SSE.fromBytes(failing))
+    expect(seen).toEqual([{ data: "ok" }])
+    expect(failuresOf(exit)).toEqual(["boom"])
+  })
+
+  it("discards buffered partial data when the stream is interrupted", async () => {
+    const { seen, exit } = await Effect.runPromise(
+      Effect.gen(function* () {
+        const seen: Array<SSE.Event> = []
+        const latch = yield* Deferred.make<void>()
+        const hanging = Stream.concat(bytesOf("data: good\n\ndata: partial"), Stream.never)
+        const fiber = yield* Stream.runForEach(SSE.fromBytes(hanging), (e) =>
+          Effect.sync(() => {
+            seen.push(e)
+          }).pipe(Effect.andThen(Deferred.succeed(latch, void 0))),
+        ).pipe(Effect.forkChild)
+        yield* Deferred.await(latch)
+        yield* Fiber.interrupt(fiber)
+        const exit = yield* Fiber.await(fiber)
+        return { seen, exit }
+      }),
+    )
+    expect(seen).toEqual([{ data: "good" }])
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(failuresOf(exit)).toEqual([])
+  })
+
+  it("ignores retry directives", async () => {
+    const out = await collect(SSE.fromBytes(bytesOf("retry: 3000\n\ndata: a\n\n")))
+    expect(out).toEqual([{ data: "a" }])
+  })
+
+  it("treats an explicit 'event: message' as the default event", async () => {
+    const out = await collect(SSE.fromBytes(bytesOf("event: message\ndata: x\n\n")))
+    expect(out).toEqual([{ data: "x" }])
+  })
+
+  it("does not dispatch events with no data", async () => {
+    const out = await collect(SSE.fromBytes(bytesOf("event: ping\n\ndata: x\n\n")))
+    expect(out).toEqual([{ data: "x" }])
   })
 
   it("ignores empty blocks between events", async () => {

--- a/packages/core/src/streaming/SSE.test.ts
+++ b/packages/core/src/streaming/SSE.test.ts
@@ -1,4 +1,4 @@
-import { Cause, Deferred, Effect, Exit, Fiber, Stream } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Result, Stream } from "effect"
 import { describe, expect, it } from "vitest"
 import * as SSE from "./SSE.js"
 
@@ -8,17 +8,17 @@ const bytesOf = (...chunks: ReadonlyArray<string>) =>
 
 const collect = <A, E>(s: Stream.Stream<A, E>) => Effect.runPromise(Stream.runCollect(s))
 
-const runUntilEnd = <A>(s: Stream.Stream<A, unknown>) =>
+const runUntilEnd = <A, E>(s: Stream.Stream<A, E>) =>
   Effect.runPromise(
-    Effect.gen(function* () {
-      const seen: Array<A> = []
-      const exit = yield* Stream.runForEach(s, (a) =>
-        Effect.sync(() => {
-          seen.push(a)
-        }),
-      ).pipe(Effect.exit)
-      return { seen, exit }
-    }),
+    s.pipe(
+      Stream.map((a): Result.Result<A, E> => Result.succeed(a)),
+      Stream.catch((e) => Stream.succeed<Result.Result<A, E>>(Result.fail(e))),
+      Stream.runCollect,
+      Effect.map((results) => ({
+        seen: results.filter(Result.isSuccess).map((r) => r.success),
+        failures: results.filter(Result.isFailure).map((r) => r.failure),
+      })),
+    ),
   )
 
 const failuresOf = (exit: Exit.Exit<unknown, unknown>): ReadonlyArray<unknown> =>
@@ -75,9 +75,9 @@ describe("SSE.fromBytes", () => {
       bytesOf("data: good\n\ndata: partial-tr"),
       Stream.fail("boom" as const),
     )
-    const { seen, exit } = await runUntilEnd(SSE.fromBytes(failing))
+    const { seen, failures } = await runUntilEnd(SSE.fromBytes(failing))
     expect(seen).toEqual([{ data: "good" }])
-    expect(failuresOf(exit)).toEqual(["boom"])
+    expect(failures).toEqual(["boom"])
   })
 
   it("discards a partial multi-byte char in the text decoder when the upstream fails", async () => {
@@ -86,9 +86,9 @@ describe("SSE.fromBytes", () => {
       Stream.fromIterable([enc.encode("data: ok\n\n"), partialSquid]),
       Stream.fail("boom" as const),
     )
-    const { seen, exit } = await runUntilEnd(SSE.fromBytes(failing))
+    const { seen, failures } = await runUntilEnd(SSE.fromBytes(failing))
     expect(seen).toEqual([{ data: "ok" }])
-    expect(failuresOf(exit)).toEqual(["boom"])
+    expect(failures).toEqual(["boom"])
   })
 
   it("discards buffered partial data when the stream is interrupted", async () => {

--- a/packages/core/src/streaming/SSE.test.ts
+++ b/packages/core/src/streaming/SSE.test.ts
@@ -11,8 +11,7 @@ const collect = <A, E>(s: Stream.Stream<A, E>) => Effect.runPromise(Stream.runCo
 const runUntilEnd = <A, E>(s: Stream.Stream<A, E>) =>
   Effect.runPromise(
     s.pipe(
-      Stream.map((a): Result.Result<A, E> => Result.succeed(a)),
-      Stream.catch((e) => Stream.succeed<Result.Result<A, E>>(Result.fail(e))),
+      Stream.result,
       Stream.runCollect,
       Effect.map((results) => ({
         seen: results.filter(Result.isSuccess).map((r) => r.success),

--- a/packages/core/src/streaming/SSE.ts
+++ b/packages/core/src/streaming/SSE.ts
@@ -1,8 +1,9 @@
 import { Stream } from "effect"
+import { Sse } from "effect/unstable/encoding"
 
 /**
  * One Server-Sent Event. Fields per the WHATWG spec:
- * - `event`: optional event name (default "message" on the wire)
+ * - `event`: optional event name (absent for the default "message")
  * - `data`: payload, with multiple `data:` lines joined by `\n`
  * - `id`: optional last-event id
  */
@@ -12,97 +13,43 @@ export type Event = {
   readonly id?: string
 }
 
-// ---------------------------------------------------------------------------
-// Generic stream helpers (kept module-local for now; promote to a shared
-// Stream module once a third caller appears).
-// ---------------------------------------------------------------------------
+const toEvent = (wire: Sse.Event): Event => ({
+  data: wire.data,
+  ...(wire.event !== "message" && { event: wire.event }),
+  ...(wire.id !== undefined && { id: wire.id }),
+})
 
-/** Decode `Uint8Array` chunks as UTF-8, handling multi-byte boundaries. */
-const decodeText = <E, R>(self: Stream.Stream<Uint8Array, E, R>): Stream.Stream<string, E, R> =>
-  self.pipe(
-    Stream.mapAccum(
-      (): TextDecoder => new TextDecoder("utf-8"),
-      (decoder, chunk: Uint8Array) => [decoder, [decoder.decode(chunk, { stream: true })]] as const,
-      {
-        onHalt: (decoder: TextDecoder) => {
-          const tail = decoder.decode()
-          return tail.length > 0 ? [tail] : []
-        },
-      },
-    ),
-  )
-
-/** Split a text stream on a separator, buffering across chunk boundaries. */
-const splitOn =
-  (separator: string) =>
-  <E, R>(self: Stream.Stream<string, E, R>): Stream.Stream<string, E, R> =>
-    self.pipe(
-      Stream.mapAccum(
-        (): string => "",
-        (buffer, chunk: string) => {
-          const parts = (buffer + chunk).split(separator)
-          const tail = parts[parts.length - 1] ?? ""
-          return [tail, parts.slice(0, -1)] as const
-        },
-        { onHalt: (tail: string) => (tail.length > 0 ? [tail] : []) },
-      ),
-    )
-
-// ---------------------------------------------------------------------------
-// Parser
-// ---------------------------------------------------------------------------
-
-const parseField = (line: string): readonly [string, string] => {
-  const colon = line.indexOf(":")
-  if (colon < 0) return [line, ""]
-  const value = line.slice(colon + 1)
-  return [line.slice(0, colon), value.startsWith(" ") ? value.slice(1) : value]
+type ParserState = {
+  readonly parser: Sse.Parser
+  readonly out: Array<Event>
 }
 
-const parseBlock = (block: string): Event | null => {
-  const lines = block.split("\n").filter((l) => l.length > 0 && !l.startsWith(":"))
-  if (lines.length === 0) return null
-
-  const fields = lines.map(parseField)
-  const dataLines = fields.filter(([f]) => f === "data").map(([, v]) => v)
-  const event = fields.find(([f]) => f === "event")?.[1]
-  const id = fields.find(([f]) => f === "id")?.[1]
-
-  const out: { event?: string; data: string; id?: string } = {
-    data: dataLines.join("\n"),
-  }
-  if (event !== undefined) out.event = event
-  if (id !== undefined) out.id = id
-  return out as Event
+const makeParserState = (): ParserState => {
+  const out: Array<Event> = []
+  const parser = Sse.makeParser((event) => {
+    // `retry:` reconnection hints have no representation in `Event`
+    if (event._tag === "Event") out.push(toEvent(event))
+  })
+  return { parser, out }
 }
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
 
 /**
  * Decode a `Stream<Uint8Array>` (e.g. an HTTP response body) into a
- * `Stream<SSE.Event>`. Handles partial UTF-8 sequences, CRLF/LF line
- * endings, and events split across chunk boundaries.
+ * `Stream<SSE.Event>`, using the spec parser from `effect/unstable/encoding`.
+ * An event is dispatched only once its terminating blank line arrives, so a
+ * partial event at stream end (clean or failed) is discarded per the spec
+ * rather than surfaced as a truncated frame.
  */
 export const fromBytes = <E, R>(
   self: Stream.Stream<Uint8Array, E, R>,
 ): Stream.Stream<Event, E, R> =>
   self.pipe(
-    decodeText,
-    Stream.map((s) => s.replace(/\r/g, "")), // SSE allows CRLF; normalize to LF
-    splitOn("\n\n"),
-    Stream.map(parseBlock),
-    Stream.filter((ev): ev is Event => ev !== null),
+    Stream.decodeText,
+    Stream.mapAccum(makeParserState, (state, text: string) => {
+      state.parser.feed(text)
+      return [state, state.out.splice(0)] as const
+    }),
   )
-
-const eventToString = (ev: Event): string => {
-  const parts: string[] = []
-  if (ev.event !== undefined) parts.push(`event: ${ev.event}`)
-  if (ev.id !== undefined) parts.push(`id: ${ev.id}`)
-  for (const line of ev.data.split("\n")) parts.push(`data: ${line}`)
-  return parts.join("\n") + "\n\n"
-}
 
 const encoder = new TextEncoder()
 
@@ -111,4 +58,13 @@ const encoder = new TextEncoder()
  * HTTP response with `Content-Type: text/event-stream`.
  */
 export const toBytes = <E, R>(self: Stream.Stream<Event, E, R>): Stream.Stream<Uint8Array, E, R> =>
-  Stream.map(self, (ev) => encoder.encode(eventToString(ev)))
+  Stream.map(self, (ev) =>
+    encoder.encode(
+      Sse.encoder.write({
+        _tag: "Event",
+        event: ev.event ?? "message",
+        id: ev.id,
+        data: ev.data,
+      }),
+    ),
+  )


### PR DESCRIPTION
Fixes #140 (option 2, as discussed).

`SSE.fromBytes` now runs on `Sse.makeParser` from `effect/unstable/encoding` and `JSONL.fromBytes` on `Stream.decodeText` + `Channel.splitLines`. Both distinguish failure from clean completion internally, so a mid-stream failure can no longer surface the buffered partial data as a complete frame. The hand-rolled `decodeText`/`splitOn` copies are gone (about 120 lines) and the public API is unchanged: `SSE.fromBytes`/`toBytes` and `JSONL.fromBytes` keep their signatures and element types, so no provider call sites change. `SSE.toBytes` is backed by `Sse.encoder`.

One note on the wrapper: I used `Sse.makeParser` directly instead of the `Sse.decode()` channel because the channel surfaces a `retry:` directive as a terminating failure (its EventSource reconnection semantics). The facade's `Event` type has no place for retry hints, and ending the stream on one would drop any events after it, so the parser-level wrapper ignores them and keeps decoding. Happy to switch if you prefer the channel plus an explicit absorb.

Behavior changes that come with the spec parser, each pinned by a test:

- A partial event or line buffered when the stream fails is discarded and the failure propagates (the bug in #140).
- A trailing SSE event without a closing blank line at clean stream end is discarded per the WHATWG spec (previously flushed). Real providers always terminate events, including `[DONE]`. JSONL is unaffected: a final line without a trailing newline is still emitted on clean end.
- Events with no `data:` lines are not dispatched (previously emitted with empty data), an explicit `event: message` normalizes to the default, and `retry:` lines are ignored. Bare `\r` inside data payloads is preserved now that CRLF handling lives in the parser instead of a global strip.

Existing streaming tests pass unchanged apart from the trailing-event flip, and the full suite is green. The six new tests fail on `main`.