### PR TITLE
fix(core): use Schema.TaggedError instead of removed Schema.TaggedErrorClass

### DIFF
--- a/.changeset/tidy-pugs-repeat.md
+++ b/.changeset/tidy-pugs-repeat.md
@@ -1,0 +1,11 @@
+---
+"@effect-uai/core": patch
+---
+
+Use `Schema.TaggedError` instead of the removed `Schema.TaggedErrorClass`
+
+Effect renamed `Schema.TaggedErrorClass` to `Schema.TaggedError` in
+`4.0.0-beta.104`. `Tool.ts` still called the old name, so importing
+`@effect-uai/core/Tool` threw `TypeError: Schema.TaggedErrorClass is not a
+function` on every Effect from `beta.104` onward, including the current `beta`
+and `rc` dist-tags. The argument shape is unchanged, so this is a rename only.

--- a/packages/core/src/tool/Tool.ts
+++ b/packages/core/src/tool/Tool.ts
@@ -4,7 +4,7 @@ import type { ToolCall, ToolCallOutput } from "../domain/Items.js"
 import { toolCallOutput } from "../domain/Items.js"
 import { serializeValue } from "./ToolResult.js"
 
-export class ToolError extends Schema.TaggedErrorClass<ToolError>("@betalyra/effect-uai/ToolError")(
+export class ToolError extends Schema.TaggedError<ToolError>("@betalyra/effect-uai/ToolError")(
   "ToolError",
   {
     call_id: Schema.String,
@@ -30,7 +30,7 @@ const ToolValidationIssue = Schema.Struct({
  * contract violation apart from a parse or execution failure, and so the
  * structured `issues` survive instead of being flattened into a message string.
  */
-export class ToolValidationError extends Schema.TaggedErrorClass<ToolValidationError>(
+export class ToolValidationError extends Schema.TaggedError<ToolValidationError>(
   "@betalyra/effect-uai/ToolValidationError",
 )("ToolValidationError", {
   call_id: Schema.String,
@@ -47,12 +47,13 @@ export class ToolValidationError extends Schema.TaggedErrorClass<ToolValidationE
  * (default `"tool_failed"`) so a tool can hand the model a distinguishable
  * category (`"not_found"`, `"rate_limited"`) without a new result variant.
  */
-export class ToolFailed extends Schema.TaggedErrorClass<ToolFailed>(
-  "@betalyra/effect-uai/ToolFailed",
-)("ToolFailed", {
-  message: Schema.String,
-  kind: Schema.optional(Schema.String),
-}) {}
+export class ToolFailed extends Schema.TaggedError<ToolFailed>("@betalyra/effect-uai/ToolFailed")(
+  "ToolFailed",
+  {
+    message: Schema.String,
+    kind: Schema.optional(Schema.String),
+  },
+) {}
 
 /**
  * Fail a tool's `run` with a model-visible message (optionally a `kind`).


### PR DESCRIPTION
Renames `Schema.TaggedErrorClass` → `Schema.TaggedError` at the three call sites in `packages/core/src/tool/Tool.ts` (L7 `ToolError`, L33 `ToolValidationError`, L50 `ToolFailed`).

Effect renamed this at `4.0.0-beta.104`, so `@effect-uai/core@0.12.0` throws at import time on every `effect` behind the current `beta` and `rc` tags. Details and repro in #169.

The released `TaggedError` keeps the same optional leading `identifier` argument, so the arguments carry over untouched.

**CI will fail on this PR, expectedly.** `packages/core` pins `effect: "4.0.0-beta.94"`, which has only the old name, so the rename can't typecheck against the current pin. The `effect` devDependency needs to move to `>= 4.0.0-beta.104` — 18 package.json files plus the lockfile. I left that out since it's your call and `chore/pnpm-catalog` is in flight; say the word and I'll push it here.

**Verified:** with the rename, `packages/core` typechecks clean against `rc.111`; without it, 8 errors, all cascading from those three lines.
